### PR TITLE
Only log Slack messages if a secret ID and a webhook isn't specified

### DIFF
--- a/server/src/slack.ts
+++ b/server/src/slack.ts
@@ -26,8 +26,8 @@ async function getSlackWebHook() {
 }
 
 export async function sendMessage(message: string): Promise<any> {
-  const { SLACK_WEB_HOOK, SLACK_TARGET_CHANNEL } = process.env;
-  if (!SLACK_TARGET_CHANNEL || !SLACK_WEB_HOOK) {
+  const { SLACK_WEB_HOOK, WEBHOOK_SECRET_ID } = process.env;
+  if (!SLACK_WEB_HOOK && !WEBHOOK_SECRET_ID) {
     console.log(`Slack alert ${prepareSlackMessage(message)}`);
     return;
   }


### PR DESCRIPTION
The way this was set previously meant that if you specified a AWS SM secret ID the message would be logged to the console rather than sent to Slack