### PR TITLE
Add example deployment using AWS Fargate

### DIFF
--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,5 +1,3 @@
-# We build listo manually as we want to add some data into the container
-# We don't want to have a trip to dockerhub if this image doesn't exist locally (e.g. docker build --pull=false but that's not the default)
-FROM listo:pleasedontgotodockerhub
+FROM seek/listo:latest
 ADD data /etc/listo/data
 ENV DATA_DIR=/etc/listo/data

--- a/examples/deploy/Makefile
+++ b/examples/deploy/Makefile
@@ -1,10 +1,27 @@
-DOCKER_REPO_URL = 6666666666.dkr.ecr.ap-southeast-2.amazonaws.com/listo
+DOCKER_REPO_URL = <your AWS account ID>.dkr.ecr.ap-southeast-2.amazonaws.com/listo
 
-deploy: 
-	docker build github.com/seek-oss/listo -t listo:pleasedontgotodockerhub
-	# avoid --pull=false is to ensure we don't pull listo from dockerhub (which it's not on)
-	docker build --pull=false -t "$(DOCKER_REPO_URL):${BUILDKITE_BUILD_NUMBER}" .
-	docker push "$(DOCKER_REPO_URL):${BUILDKITE_BUILD_NUMBER}"
-	[REPLACE WITH CONTAINER DEPLOY TOOL]
+deploy:
+	docker build github.com/seek-oss/listo -t seek/listo:latest
+	docker build --pull=false -t "$(DOCKER_REPO_URL):${BUILD_NUMBER}" .
+	docker push "$(DOCKER_REPO_URL):${BUILD_NUMBER}"
+	aws cloudformation deploy \
+		--template-file stack.yaml \
+		--stack-name listo \
+		--no-fail-on-empty-changeset \
+		--parameter-overrides \
+			'ImageUrl=$(DOCKER_REPO_URL):${BUILD_NUMBER}' \
+			'VpcID=<Your vpc id>' \
+			'PublicSubnetIds=<Your subnet ids>' \
+			'PrivateSubnetIds=<Your subnet ids>' \
+			'TrelloTeam=<Id of your trello team>' \
+			'CertificateArn=<ARN of your ACM Certificate for TLS>' \
+			'OidcAuthorizationEndpoint=<Your oidc authz endpoint>' \
+			'OidcClientId=<Your oidc client id>' \
+			'OidcClientSecret=<Your oidc client secret>' \
+			'OidcIssuer=<Your oidc issuer url>' \
+			'OidcTokenEndpoint=<Your oidc token url>' \
+			'OidcUserInfoEndpoint=<Your oidc user info url>' \
+			'AlbHostedZoneId=<Route53 zone ID for the DNS record>' \
+			'AlbDnsName=<DNS name to assign the load balancer, e.g. listo.example.com>'
 
 .PHONY: deploy

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -1,0 +1,20 @@
+# Deploying Listo
+
+This folder serves as an **example** for how Listo can be deployed to AWS.
+
+ - `ecr.yaml` - CloudFormation stack for the ECR repository
+ - `stack.yaml` - CloudFormation stack that:
+   1. Creates an ALB to authenticate users with the OIDC-compatible IdP of your choice
+   2. Launches Listo within Fargate
+   3. Creates some AWS Secrets Manager secrets for a Slack Webhook and your Trello Credentials
+   4. Creates a DynamoDB table for storing Listo projects
+   5. Sets up a AWS CloudWatch log group called `/listo`
+ - `Makefile` - Sample Makefile for building and deploying Listo into AWS using the above stack
+ - `Dockerfile` - Sample Dockerfile that embeds custom data, as volumes 
+
+# To use this example
+
+ 1. Deploy `ecr.yaml` to your AWS account via AWS CloudFormation (this can be done in the UI)
+ 2. Update the `Makefile` with your own settings (OIDC details, VPC settings, DNS settings, etc)
+ 3. Deploy Listo `make deploy`
+ 4. Update the secret values in the AWS Secrets Manager secrets created in deployment (Slack WebHook and Trello Credentials)

--- a/examples/deploy/ecr.yaml
+++ b/examples/deploy/ecr.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  ContainerRepo:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: listo
+      LifecyclePolicy:
+        LifecyclePolicyText: >
+          {
+            "rules": [
+                {
+                    "rulePriority": 1,
+                    "description": "Keep only 10 images",
+                    "selection": {
+                        "tagStatus": "any",
+                        "countType": "imageCountMoreThan",
+                        "countNumber": 10
+                    },
+                    "action": {
+                        "type": "expire"
+                    }
+                }
+            ]
+          }

--- a/examples/deploy/stack.yaml
+++ b/examples/deploy/stack.yaml
@@ -1,0 +1,332 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Stack for deploying listo into AWS Fargate
+Parameters:
+  ImageUrl:
+    Description: URL for the listo docker image
+    Type: String
+
+  VpcId:
+    Description: VPC to deploy in
+    Type: AWS::EC2::VPC::Id
+
+  PublicSubnetIds:
+    Description: Subnets exposed to the internet, used for the load balancer
+    Type: List<AWS::EC2::Subnet::Id>
+
+  PrivateSubnetIds:
+    Description: Private subnets
+    Type: List<AWS::EC2::Subnet::Id>
+
+  ServiceName:
+    Type: String
+    Default: listo
+
+  TrelloTeam:
+    Type: String
+
+  CertificateArn:
+    Description: ACM certificate for the load balancer
+    Type: String
+
+  OidcAuthorizationEndpoint:
+    Description: Authorization endpoint of the IdP
+    Type: String
+
+  OidcClientId:
+    Description: The OAuth 2.0 client identifier
+    Type: String
+
+  OidcClientSecret:
+    Description: The OAuth 2.0 client secret
+    Type: String
+    NoEcho: true
+
+  OidcIssuer:
+    Description: The OIDC issuer identifier of the IdP. This must be a full URL, including the HTTPS protocol, the domain, and the path.
+    Type: String
+
+  OidcTokenEndpoint:
+    Description: The token endpoint of the IdP. This must be a full URL, including the HTTPS protocol, the domain, and the path.
+    Type: String
+
+  OidcUserInfoEndpoint:
+    Description: The user info endpoint of the IdP. This must be a full URL, including the HTTPS protocol, the domain, and the path.
+    Type: String
+
+  AlbHostedZoneId:
+    Description: The Route53 zone ID for creating a DNS record to the ALB
+    Type: String
+
+  AlbDnsName:
+    Description: The DNS name to assign the load balancer, e.g. listo.example.com
+    Type: String
+Resources:
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: listo-alb-security-group
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: '0.0.0.0/0'
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: '0.0.0.0/0'
+
+  Alb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+      Subnets: !Ref PublicSubnetIds
+      LoadBalancerAttributes:
+       - Key: idle_timeout.timeout_seconds
+         Value: 60
+       - Key: deletion_protection.enabled
+         Value: true
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
+        # enforce authentication on all requests
+        - Type: authenticate-oidc
+          AuthenticateOidcConfig:
+            AuthorizationEndpoint: !Ref OidcAuthorizationEndpoint
+            ClientId: !Ref OidcClientId
+            ClientSecret: !Ref OidcClientSecret
+            Issuer: !Ref OidcIssuer
+            TokenEndpoint: !Ref OidcTokenEndpoint
+            UserInfoEndpoint: !Ref OidcUserInfoEndpoint
+          Order: 1
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+          Order: 2
+      LoadBalancerArn: !Ref Alb
+      Port: 443
+      Protocol: HTTPS
+
+  HttpRedirectListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Host: '#{host}'
+            Path: '/#{path}'
+            Port: 443
+            Protocol: 'HTTPS'
+            Query: '#{query}'
+            StatusCode: HTTP_301
+      LoadBalancerArn: !Ref Alb
+      Port: 80
+      Protocol: HTTP
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: '/health'
+      HealthCheckTimeoutSeconds: 5
+      UnhealthyThresholdCount: 2
+      HealthyThresholdCount: 2
+      Port: 8080
+      Protocol: HTTP
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      TargetType: ip
+      VpcId: !Ref VpcId
+
+  AlbDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref AlbHostedZoneId
+      Name: !Ref AlbDnsName
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt Alb.DNSName
+        HostedZoneId: !GetAtt Alb.CanonicalHostedZoneID
+
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: listo
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: 256
+      Memory: 512
+      ExecutionRoleArn: !Ref ExecutionRole
+      TaskRoleArn: !Ref TaskRole
+      ContainerDefinitions:
+        - Name: !Ref ServiceName
+          Image: !Ref ImageUrl
+          PortMappings:
+            - ContainerPort: 8000
+          Environment:
+            - Name: WEBHOOK_SECRET_ID
+              Value: !Ref SlackWebHookSecret
+            - Name: TRELLO_SCRET_ID
+              Value: !Ref TrelloCredentialsSecret
+            - Name: DYNAMODB_TABLE
+              Value: !Ref BoardsTable
+            - Name: TRELLO_TEAM
+              Value: !Ref TrelloTeam
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Ref AWS::Region
+              awslogs-group: !Ref LogGroup
+              awslogs-stream-prefix: ecs
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Path: '/'
+      Policies:
+        - PolicyName: read-s3
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref TrelloCredentialsSecret
+                  - !Ref SlackWebHookSecret
+              - Effect: Allow
+                Action:
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
+                Resource: !GetAtt BoardsTable.Arn
+
+  AutoScalingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole
+
+  ContainerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub '${ServiceName}-sg'
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8000
+          ToPort: 8000
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+
+  ListoService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref Cluster
+      TaskDefinition: !Ref TaskDefinition
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+      DesiredCount: 2
+      HealthCheckGracePeriodSeconds: 30
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets: !Ref PrivateSubnetIds
+          SecurityGroups:
+            - !Ref ContainerSecurityGroup
+      LoadBalancers:
+        - ContainerName: !Ref ServiceName
+          ContainerPort: 8000
+          TargetGroupArn: !Ref TargetGroup
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /listo
+      RetentionInDays: 14
+
+  AutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MinCapacity: 1
+      MaxCapacity: 5
+      ResourceId: !Sub 'service/${Cluster}/${ListoService.Name}'
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      RoleARN: !GetAtt AutoScalingRole.Arn
+
+  AutoScalingPolicy:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: !Sub '${ServiceName}-asp'
+      PolicyType: TargetTrackingScaling
+      ScalingTargetId: !Ref AutoScalingTarget
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        ScaleInCooldown: 10
+        ScaleOutCooldown: 10
+        TargetValue: 75
+
+  BoardsTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      TableName: listo-boards
+
+  TrelloCredentialsSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: listo/trello-credentials
+      Description: Trello API credentials for Listo
+
+  SlackWebHookSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: listo/slack-web-hook
+      Description: Slack webhook for Listo


### PR DESCRIPTION
This serves as an example for how Listo can be run on AWS Fargate, including authenticating users via AWS ALB OIDC support