### PR TITLE
Heroku deployable version of Listo  as per #7

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - v*
+      - 'v/*'
 
 env:
   IMAGE_NAME: listoproject/listo
@@ -19,19 +19,16 @@ jobs:
     - name: Build image
       run: docker build . --file Dockerfile --tag $IMAGE_NAME
     - name: Log into registry
-      run: echo "${{ secrets.DOCKER_API_KEY }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      run: docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin <<< "${{ secrets.DOCKER_API_KEY }}"
     - name: Push image
       run: | 
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-        
-        # Strip "v" prefix from tag name
-        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-        # Use Docker `latest` tag convention
-        [ "$VERSION" == "master" ] && VERSION=latest
-
-        echo VERSION=$VERSION
+        if [[ "${{ github.ref }}" =~ ^refs/tags/v/(.*) ]] ; then
+          VERSION="${BASH_REMATCH[1]}"
+        elif [[ "${{ github.ref }}" =~ ^refs/heads/master ]] ; then
+          VERSION="latest"
+        else
+          VERSION="unknown"
+        fi
 
         docker tag image $IMAGE_NAME:$VERSION  
         docker push $IMAGE_NAME:$VERSION

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
 env:
   IMAGE_NAME: listoproject/listo
@@ -19,7 +21,20 @@ jobs:
     - name: Log into registry
       run: echo "${{ secrets.DOCKER_API_KEY }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
     - name: Push image
-      run: docker push $IMAGE_NAME:latest 
+      run: | 
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "master" ] && VERSION=latest
+
+        echo VERSION=$VERSION
+
+        docker tag image $IMAGE_NAME:$VERSION  
+        docker push $IMAGE_NAME:$VERSION
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,0 +1,39 @@
+name: Build Listo, Push to Dockerhub and Deploy to Heroku
+
+on: 
+  push:
+    branches:
+      - master
+
+env:
+  IMAGE_NAME: listoproject/listo
+  HEROKU_APP_NAME: listo-demo
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build image
+      run: docker build . --file Dockerfile --tag $IMAGE_NAME
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_API_KEY }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+    - name: Push image
+      run: docker push $IMAGE_NAME:latest 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Login to Heroku Container registry
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:login 
+    - name: Build and push
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:push -a $HEROKU_APP_NAME web --recursive 
+    - name: Release
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:release -a $HEROKU_APP_NAME web

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM jberton/listo:latest
+ADD data /etc/listo/data
+ENV DATA_DIR=/etc/listo/data
+ENV DISK_PATH=/opt/listo/db.json

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM jberton/listo:latest
+FROM listoproject/listo:latest 
 ADD data /etc/listo/data
 ENV DATA_DIR=/etc/listo/data
 ENV DISK_PATH=/opt/listo/db.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 Use questionnaires and checklists to make it easy to do the right thing, regarding the software you build.
 
+Want to see Listo in action? Checkout the demo here: [https://listo-demo.herokuapp.com/](https://listo-demo.herokuapp.com/)!
 
 ## About
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,8 @@ services:
     image: listo
     build: .
     environment:
-      - DYNAMO_DB_ENDPOINT=http://database:8000
       - DATA_DIR=/etc/listo/data
-      - CREATE_DYNAMO_TABLES=true
-      - AWS_ACCESS_KEY_ID
-      - AWS_SESSION_TOKEN
-      - AWS_SECRET_ACCESS_KEY
+      - DISK_PATH=/opt/listo/db.json
       - TRELLO_API_KEY
       - TRELLO_TOKEN
       - TRELLO_TEAM
@@ -22,10 +18,3 @@ services:
         - ./data:/etc/listo/data:ro
     ports:
       - 8000:8000
-    links:
-      - database
-
-  database:
-    image: amazon/dynamodb-local
-    ports:
-      - 8000

--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM seek/listo:latest
+FROM listoproject/listo:latest
 ADD data /etc/listo/data
 ENV DATA_DIR=/etc/listo/data
 ENV DISK_PATH=/opt/listo/db.json

--- a/examples/deploy/Dockerfile
+++ b/examples/deploy/Dockerfile
@@ -1,3 +1,4 @@
 FROM seek/listo:latest
 ADD data /etc/listo/data
 ENV DATA_DIR=/etc/listo/data
+ENV DISK_PATH=/opt/listo/db.json

--- a/examples/deploy/Makefile
+++ b/examples/deploy/Makefile
@@ -24,4 +24,12 @@ deploy:
 			'AlbHostedZoneId=<Route53 zone ID for the DNS record>' \
 			'AlbDnsName=<DNS name to assign the load balancer, e.g. listo.example.com>'
 
+deploy_heroku:
+	docker build github.com/seek-oss/listo -t seek/listo:latest
+	docker build --pull=false -t "$(DOCKER_REPO_URL):${BUILD_NUMBER}" .
+	docker push "$(DOCKER_REPO_URL):${BUILD_NUMBER}"
+	heroku container:push --recursive --app [YOUR_APP_NAME]
+	heroku container:release --app [YOUR_APP_NAME] web
+
+
 .PHONY: deploy

--- a/examples/deploy/Makefile
+++ b/examples/deploy/Makefile
@@ -25,10 +25,8 @@ deploy:
 			'AlbDnsName=<DNS name to assign the load balancer, e.g. listo.example.com>'
 
 deploy_heroku:
-	docker build github.com/seek-oss/listo -t seek/listo:latest
-	docker build --pull=false -t "$(DOCKER_REPO_URL):${BUILD_NUMBER}" .
-	docker push "$(DOCKER_REPO_URL):${BUILD_NUMBER}"
-	heroku container:push --recursive --app [YOUR_APP_NAME]
+	heroku container:login 
+	heroku container:push --recursive --app [YOUR_APP_NAME] web
 	heroku container:release --app [YOUR_APP_NAME] web
 
 

--- a/examples/deploy/README.md
+++ b/examples/deploy/README.md
@@ -1,7 +1,8 @@
 # Deploying Listo
 
-This folder serves as an **example** for how Listo can be deployed to AWS.
+This folder serves as an **example** for how Listo can be deployed to AWS and Heroku.
 
+## AWS
  - `ecr.yaml` - CloudFormation stack for the ECR repository
  - `stack.yaml` - CloudFormation stack that:
    1. Creates an ALB to authenticate users with the OIDC-compatible IdP of your choice
@@ -12,9 +13,16 @@ This folder serves as an **example** for how Listo can be deployed to AWS.
  - `Makefile` - Sample Makefile for building and deploying Listo into AWS using the above stack
  - `Dockerfile` - Sample Dockerfile that embeds custom data, as volumes 
 
-# To use this example
+### To use this example
 
  1. Deploy `ecr.yaml` to your AWS account via AWS CloudFormation (this can be done in the UI)
  2. Update the `Makefile` with your own settings (OIDC details, VPC settings, DNS settings, etc)
  3. Deploy Listo `make deploy`
  4. Update the secret values in the AWS Secrets Manager secrets created in deployment (Slack WebHook and Trello Credentials)
+
+## Heroku
+
+- Create a container application within your account and add the relevant environment variables to the Config Vars (Trello creds is the only mandatory vars to add).
+- Create a new repo with your customised data directory and the Dockerfile.web.
+- [manually] Add your application details to the Makefile and then run `make deploy_heroku`.
+- [via CI] Checkout how we have deployed listo to Heroku using [Github Actions](heroku_deploy.yml).

--- a/examples/deploy/heroku_deploy.yml
+++ b/examples/deploy/heroku_deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy Listo to Heroku 
+
+on: 
+  push:
+    branches:
+      - master
+
+env:
+  IMAGE_NAME: listoproject/listo
+  HEROKU_APP_NAME: listo-demo
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Login to Heroku Container registry
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:login 
+    - name: Build and push
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:push -a $HEROKU_APP_NAME web --recursive 
+    - name: Release
+      env: 
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      run: heroku container:release -a $HEROKU_APP_NAME web

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,6 +1,3 @@
-export CREATE_DYNAMO_TABLES=true
-export DYNAMO_DB_ENDPOINT=http://localhost:9000
-
 install:
 	yarn install
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,7 @@ import { region } from './config';
 
 const DATA_DIR = process.env.DATA_DIR || '../data';
 const SCHEMA_PATH = process.env.SCHEMA_PATH || '../frontend/data-schema.json';
-const PORT = process.env.LISTO_SERVER_PORT || 8000;
+const PORT = process.env.PORT || 8000;
 
 (async function() {
   try {

--- a/server/src/diskdb.ts
+++ b/server/src/diskdb.ts
@@ -9,7 +9,7 @@ export class Disk implements Repository {
   diskPath: string;
 
   constructor(diskPath: string) {
-    this.diskPath = diskPath || './db.json';
+    this.diskPath = diskPath || './db/db.json';
   }
 
   async saveDB() {

--- a/server/src/diskdb.ts
+++ b/server/src/diskdb.ts
@@ -9,7 +9,7 @@ export class Disk implements Repository {
   diskPath: string;
 
   constructor(diskPath: string) {
-    this.diskPath = diskPath || './db/db.json';
+    this.diskPath = diskPath || './db.json';
   }
 
   async saveDB() {

--- a/server/src/dynamodb.ts
+++ b/server/src/dynamodb.ts
@@ -21,7 +21,7 @@ export class Dynamo implements Repository {
   }
 
   public async init() {
-    if (process.env.CREATE_DYNAMO_TABLES) {
+    if (process.env.LISTO_DATABASE === 'Dynamo' && process.env.CREATE_DYNAMO_TABLES) {
       const params = {
         TableName: this.tableName,
         KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],


### PR DESCRIPTION
This will allow us to create a demo website that can be linked to the readme to give users a better idea of the tool. It will also help others quickly deploy their own version of Listo to Heroku. Heroku have a free tier which has everything we need to host a basic demo of Listo. It also allows teams which would allow me to add you both to the account. The Disk database will be used and stored in ephemeral storage on the container. It will get wiped every time the "Dyno" is restarted. Which is often with the free tier. Perfect for our situation. The Trello boards will persist within the Test Trello account however.  

https://listo-demo.herokuapp.com/

ToDo
- [x] Create a test Trello account for this demo site as they are free also. Currently using my account.
- [x] Create a readme to help (us) and other people to deploy to Heroku. Making it easier to deploy the tool.
- [x] Deploy the listo docker container to Dockerhub (https://hub.docker.com/r/listoproject/listo).
- [x] Add a link to the demo site to the main readme. 