### PR TITLE
Reduced the number of API requests sent to Trello concurrently

### DIFF
--- a/server/src/tests.ts
+++ b/server/src/tests.ts
@@ -24,6 +24,41 @@ const TEST_DATA = {
   Trello: 'https://trello.com/b/dsfadsfafsdf',
 };
 
+const TEST_DATA_FULL_BOARD = {
+  selectedRisks: [
+    {
+      text:
+        'Do you want supporting teams such as Security and Architecture to reach out throughout the project?',
+      selection: 'Yes',
+    },
+  ],
+  selectedModulesByCategory: {
+    code: [
+      'authentication',
+      'authorisation',
+      'csrf',
+      'internal_libs',
+      'open_source',
+      'third_party_libs',
+      'urls',
+      'xml',
+      'xss',
+    ],
+    data: ['general', 'nosql', 'object_store', 'rds'],
+    general: ['abuse', 'services', 'telemetry', 'threat_modeling'],
+    service_provider: ['aws', 'datacentre'],
+    software_env: ['containers', 'servers'],
+  },
+  projectMetaResponses: {
+    boardName: 'Google Doodle',
+    slackTeam: 'awesome',
+    slackUserName: 'julian',
+    trelloEmail: 'asdfd@sdfadf',
+    riskLevel: 'High Risk',
+  },
+  selectedTools: ['Gantry'],
+};
+
 const TEST_DATA_CREATE = {
   selectedRisks: [
     {


### PR DESCRIPTION
Reduced the number of API requests sent to Trello concurrently so that we don't hit their rate limits described here: https://help.trello.com/article/838-api-rate-limits.

Also added some error checking to make sure the rate limit errors are not suppressed and are logged.