### PR TITLE
Support a custom server url via SERVER_URL

### DIFF
--- a/examples/TEMPLATE_env.sh
+++ b/examples/TEMPLATE_env.sh
@@ -26,3 +26,6 @@ export SLACK_TARGET_CHANNEL='#listo'
 
 # OPTIONAL - Slack Channel Deep link - https://api.slack.com/reference/deep-linking
 # export SLACK_CHANNEL_LINK='https://slack.com/app_redirect?channel=listo&team=T02P5698'
+
+# OPTIONAL - Server URL, e.g. if the server hosting listo is fronted by a load balancer or reverse proxy
+# export SERVER_URL='https://example.com'

--- a/server/src/appFactory.ts
+++ b/server/src/appFactory.ts
@@ -24,11 +24,8 @@ function buildProjectURL(
   host: string,
   projectId: string,
 ): string {
-  let authority = `${scheme}://${host}`;
   // Support a custom URL, e.g. if listo is behind a reverse proxy
-  if (SERVER_URL) {
-    authority = SERVER_URL.replace(/\/$/, '');
-  }
+  const authority = SERVER_URL ? SERVER_URL.replace(/\/$/, '') : `${scheme}://${host}`;
   return `${authority}/project/${projectId}`;
 }
 

--- a/server/src/appFactory.ts
+++ b/server/src/appFactory.ts
@@ -16,6 +16,7 @@ const {
   SLACK_CHANNEL_LINK,
   SLACK_TARGET_CHANNEL,
   TRELLO_BOARD_LINK,
+  SERVER_URL
 } = process.env;
 
 function buildProjectURL(
@@ -23,7 +24,12 @@ function buildProjectURL(
   host: string,
   projectId: string,
 ): string {
-  return `${scheme}://${host}/project/${projectId}`;
+  let authority = `${scheme}://${host}`;
+  // Support a custom URL, e.g. if listo is behind a reverse proxy
+  if (SERVER_URL) {
+    authority = SERVER_URL.replace(/\/$/, '');
+  }
+  return `${authority}/project/${projectId}`;
 }
 
 function addMandatoryModules(


### PR DESCRIPTION
In cases where Listo is behind a load balancer or reverse proxy, it's desirable to specify a custom URL rather than using the scheme/host from the HTTP request as this may not be the URL listo was accessed through.

I've opted for a config rather than trying to parse "proxy" headers as these are notoriously non-standard.